### PR TITLE
Basic認証の設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,16 @@
+class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+end


### PR DESCRIPTION
# WHAT
本番環境でbasic認証を導入する
# WHY
今回作成するコピーサイトは、デフォルトでは世界中の誰でもアクセスできる状態にあります。誤ってアクセスしたユーザーに誤解を生むことがないように、Basic認証を導入して閲覧できるユーザーを制限しましょう。