### PR TITLE
出品中の商品の削除

### DIFF
--- a/app/assets/stylesheets/items/_show_deleted.scss
+++ b/app/assets/stylesheets/items/_show_deleted.scss
@@ -162,6 +162,7 @@
       line-height: 90px;
       margin-top: 100px;
       font-weight: bold;
+      position: relative;
     }
     .main_contents {
       height: 750px;
@@ -296,4 +297,14 @@
       }
     }
   }
+}
+.go_to_top{
+  width: 40%;
+  height: 70px;
+  color: white;
+  background-color:red;
+  text-align: center;
+  line-height: 70px;
+  margin:0 auto;
+  margin-bottom: 3%;
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,7 +121,7 @@ class ItemsController < ApplicationController
     @item = Item.find(session[:item_id])
     session[:item_id] = nil
     @item.update(exhibition_state: "削除済")
-    user = User.find(@item.user_id)
+    user = User.find_by(@item.user_id)
     redirect_to controller: 'users', action: 'show', id: user.id
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,7 +121,7 @@ class ItemsController < ApplicationController
     @item = Item.find(session[:item_id])
     session[:item_id] = nil
     @item.update(exhibition_state: "削除済")
-    user = User.find_by(@item.user_id)
+    user = User.where(@item.user_id)
     redirect_to controller: 'users', action: 'show', id: user.id
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,7 +89,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    session[:item_id] = @item.id
+     session[:item_id] = @item.id
     if @item.exhibition_state == "削除済"
       redirect_to controller: 'items', action: 'show_deleted'
     end
@@ -118,11 +118,11 @@ class ItemsController < ApplicationController
   end
 
   def item_destroy
-    @item = Item.find(session[:item_id])
-    session[:item_id] = nil
-    @item.update(exhibition_state: "削除済")
-    user = User.find(@item.user_id)
-    redirect_to controller: 'users', action: 'show', id: user.id
+   @item = Item.find(session[:item_id])
+   session[:item_id] = nil
+   @item.update(exhibition_state: "削除済")
+   user = User.find(@item.user_id)
+   redirect_to controller: 'users', action: 'show', id: user.id
   end
 
   def bought

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,7 +121,7 @@ class ItemsController < ApplicationController
     @item = Item.find(session[:item_id])
     session[:item_id] = nil
     @item.update(exhibition_state: "削除済")
-    user = User.where(@item.user_id)
+    user = User.where(id: @item.user_id)
     redirect_to controller: 'users', action: 'show', id: user.id
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,7 +89,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-     session[:item_id] = @item.id
+    session[:item_id] = @item.id
     if @item.exhibition_state == "削除済"
       redirect_to controller: 'items', action: 'show_deleted'
     end
@@ -118,11 +118,11 @@ class ItemsController < ApplicationController
   end
 
   def item_destroy
-   @item = Item.find(session[:item_id])
-   session[:item_id] = nil
-   @item.update(exhibition_state: "削除済")
-   user = User.find(@item.user_id)
-   redirect_to controller: 'users', action: 'show', id: user.id
+    @item = Item.find(session[:item_id])
+    session[:item_id] = nil
+    @item.update(exhibition_state: "削除済")
+    user = User.find(@item.user_id)
+    redirect_to controller: 'users', action: 'show', id: user.id
   end
 
   def bought

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,7 +121,7 @@ class ItemsController < ApplicationController
     @item = Item.find(session[:item_id])
     session[:item_id] = nil
     @item.update(exhibition_state: "削除済")
-    user = User.where(id: @item.user_id)
+    user = User.find(@item.user_id)
     redirect_to controller: 'users', action: 'show', id: user.id
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -120,9 +120,15 @@ class ItemsController < ApplicationController
   def item_destroy
     @item = Item.find(session[:item_id])
     session[:item_id] = nil
-    @item.update(exhibition_state: "削除済")
-    user = User.find(@item.user_id)
-    redirect_to controller: 'users', action: 'show', id: user.id
+    if @item.update(exhibition_state: "削除済")
+      user = User.find(@item.user_id)
+      redirect_to controller: 'users', action: 'show', id: user.id
+    else
+      redirect_to error_page_items_path
+    end
+  end
+
+  def error_page
   end
 
   def bought

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -24,7 +24,7 @@ class SignupController < ApplicationController
       
 
     if @user.save
-   
+      # session[:id] = @user.id
       session[:payjpUser_id] = @user.id
       if session['devise.omniauth_data']
       sns = SnsCredential.find(session[:sns_id]) 
@@ -150,7 +150,7 @@ class SignupController < ApplicationController
   end
 
   def newend 
-    
+    # sign_in User.find(session[:id]) unless user_signed_in?
   end
   
   private

--- a/app/views/items/error_page.html.haml
+++ b/app/views/items/error_page.html.haml
@@ -3,8 +3,11 @@
   .left_auto
     =link_to "" do
       =image_tag "alltag.png", size: "300x250",class: "masa"
-  %p.midasi
-    この商品は削除されたか 存在しない商品です
+  .midasi
+    エラーが発生し、処理が中断されました
+    = link_to root_path do
+      .go_to_top
+        TOPページに戻る
 .adv
   .imagebox
     = link_to "" do

--- a/app/views/signup/new.html.haml
+++ b/app/views/signup/new.html.haml
@@ -73,7 +73,7 @@
             %br/
             .birthday-select-wrap
               .select-wrap
-                = f.select :birth_year, calss: "hijikata" do
+                = f.select :birth_year,{},{},class: "select-default" do
                   %option{value: ""} --
                   %option{value: "2019"} 2019
                   %option{value: "2018"} 2018
@@ -197,7 +197,7 @@
                   %option{value: "1900"} 1900
               %span 年
               .select-wrap.select-wrap__month
-                = f.select :birth_month, class:"hijikata" do
+                = f.select :birth_month,{},{},class: "select-default" do
                   %option{value: ""} --
                   %option{value: "1"} 1
                   %option{value: "2"} 2
@@ -211,10 +211,10 @@
                   %option{value: "10"} 10
                   %option{value: "11"} 11
                   %option{value: "12"} 12
-                
+              
               %span 月
               .select-wrap.select-wrap__day
-                = f.select :birth_day, class: 'hijikata' do
+                = f.select :birth_day,{},{},class: "select-default" do
                   %option{value: ""} --
                   %option{value: 1} 1
                   %option{value: 2} 2

--- a/app/views/users/_trading_module.html.haml
+++ b/app/views/users/_trading_module.html.haml
@@ -4,5 +4,5 @@
   .qqq or
   =link_to item_stop_path do
     .qqqq 出品を一旦中止する
-  =link_to item_deleted_path do
+  =link_to item_destroy_path do
     .qqqqq この商品を削除する

--- a/app/views/users/_trading_module.html.haml
+++ b/app/views/users/_trading_module.html.haml
@@ -4,5 +4,5 @@
   .qqq or
   =link_to item_stop_path do
     .qqqq 出品を一旦中止する
-  =link_to item_destroy_path do
+  =link_to item_deleted_path do
     .qqqqq この商品を削除する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
       collection do
         get 'show_deleted'
         post 'comment_create'
+        get 'error_page'
       end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,6 @@ Rails.application.routes.draw do
         get 'bought'
         post 'item_stop'
         post 'item_destroy'
-
       end
       collection do
         get 'show_deleted'


### PR DESCRIPTION
# WHAT
item_destroyメソッドの修正と実用化
別のマークアップブランチにてマスター実装済の_trading_module.html.hamlで使用可能にする
# WHY
商品の削除機能がなければ都合が悪くなった場合取り下げられなくなってしまうため。