### PR TITLE
商品詳細で商品購入のリンクを消す

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -77,8 +77,10 @@
         %p.byy
           送料込み
       - if @item.exhibition_state == "出品中"
-        .vmt
-          =link_to("購入画面に進む",transaction_item_path,id:@item.id,class: "iuorwe")
+        -if user_signed_in?
+          - unless @item.user.id ==current_user.id
+            .vmt
+              =link_to("購入画面に進む",transaction_item_path,id:@item.id,class: "iuorwe")
       - elsif @item.exhibition_state == "停止中"
         .vmt
           %p.iuorwe 出品停止中


### PR DESCRIPTION
#What
購入のリンクを他人が出品した商品にのみ出現させる

#Why
現状サインインしていない人でも購入リンクがあり、また自分が出品した商品にもリンクが出て購入できるため